### PR TITLE
Add search query parser

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,0 +1,10 @@
+# Taut revision history
+
+## Unreleased
+
+- Improved search, based Slack's query format
+
+## v0.1 - 2019/05/08
+
+Initial release 
+

--- a/backend/backend.cabal
+++ b/backend/backend.cabal
@@ -23,6 +23,7 @@ library
                , http-client
                , http-client-tls
                , lens
+               , megaparsec
                , mmark
                , modern-uri
                , obelisk-backend
@@ -71,6 +72,7 @@ executable backend
                , http-client
                , http-client-tls
                , lens
+               , megaparsec
                , mmark
                , modern-uri
                , modern-uri

--- a/backend/backend.cabal
+++ b/backend/backend.cabal
@@ -47,7 +47,8 @@ library
     Backend.Config
     Backend.Login
     Backend.Import
-    Backend.Query
+    Backend.Search
+    Backend.Search.Parser
   ghc-options: -Wall
 
 executable backend

--- a/backend/src/Backend.hs
+++ b/backend/src/Backend.hs
@@ -39,7 +39,8 @@ import Common.Types
 import Backend.Config
 import Backend.Import (SlackDb (..), populateDatabase, slackDb)
 import Backend.Login
-import Backend.Query
+import Backend.Search.Parser (parseSearchQuery)
+import Backend.Search
 
 
 backend :: Backend BackendRoute FrontendRoute

--- a/backend/src/Backend/Query.hs
+++ b/backend/src/Backend/Query.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
@@ -8,18 +9,76 @@
 module Backend.Query where
 
 import Data.Text (Text)
+import qualified Data.Text as T
 import Data.Time.Calendar
+import Data.Foldable (foldr1)
 import Data.Time.Clock
+import qualified Data.List.NonEmpty as NEL
+import Data.Void
+import Data.List.NonEmpty (NonEmpty (..))
 
-import Backend.Import (SlackDb (..))
 import Database.Beam
 import Database.Beam.Backend.SQL
+import Text.Megaparsec
+import Text.Megaparsec.Char
+import qualified Text.Megaparsec.Char.Lexer as L
 
 import Common.Slack.Types
 
+import Backend.Import (SlackDb (..))
+
+data SearchQuery
+  = SearchQuery_Like Text
+  | SearchQuery_Or (NonEmpty SearchQuery)
+  | SearchQuery_From Text
+  | SearchQuery_To Text
+  deriving (Show)
+
+type Parser = Parsec Void Text
+
+someTerm :: Parser Text
+someTerm = fmap T.pack $ some alphaNumChar
+
+searchQuery :: Parser SearchQuery
+searchQuery = fmap combineOr p
+  where
+    p =
+        (SearchQuery_From <$> (L.symbol space "from:" >> someTerm))
+      <|> (SearchQuery_To <$> (L.symbol space "to:" >> someTerm))
+      <|> (SearchQuery_Like . T.pack <$> some alphaNumChar) -- (sepEndBy1 printChar space1))
+    combineOr = id
+  -- <|> (SearchQuery_Or . fromJust . NEL.nonEmpty <$> sepEndBy1 searchQuery space1)
+
+demo :: IO ()
+demo = parseTest searchQuery "Hello world"
+
+data C = C
+  { _c_terms :: [Text]
+  , _c_after :: Maybe UTCTime
+  , _c_before :: Maybe UTCTime
+  , _c_during :: Maybe (Either UTCTime UTCTime)
+  , _c_from :: Maybe [Text]
+  , _c_to :: Maybe [Text]
+  }
+
+-- TODO: Provide example queries for each constructor and display that in home
+-- page. (Store queries in config file)
 data Query
   = Query_Day Day
   | Query_Like Text
+  | Query_And (NonEmpty Text)
+  -- | Query_Exact Text
+  -- | Query_Or Query Query
+  -- | Query_And Query Query
+  -- | Query_After UTCTime
+  -- | Query_Between UTCTime
+  -- | Query_During (Either Month Year)
+  -- | Query_From SlackUser
+
+parseQuery :: Text -> Query
+parseQuery query = case NEL.nonEmpty (T.words query) of
+  Nothing -> Query_Like query
+  Just qs -> Query_And qs
 
 filterQuery
   :: forall be s.
@@ -36,4 +95,7 @@ filterQuery = \case
     let fromDate = UTCTime day 0
         toDate = UTCTime (addDays 1 day) 0
     in filter_ (\msg -> (_messageTs msg >=. val_ fromDate) &&. (_messageTs msg <. val_ toDate))
-  Query_Like q -> filter_ (\msg -> (_messageText msg `like_` val_ ("%" <> q <> "%")))
+  Query_Like q -> filter_ $ msgContaining q
+  Query_And qs -> filter_ $ \msg -> foldr1 (&&.) $ flip msgContaining msg <$> qs
+  where
+    msgContaining q msg = _messageText msg `like_` val_ ("%" <> q <> "%")

--- a/backend/src/Backend/Query.hs
+++ b/backend/src/Backend/Query.hs
@@ -10,11 +10,15 @@
 module Backend.Query where
 
 import Control.Lens hiding ((<.))
+import Control.Monad
 import qualified Data.List.NonEmpty as NEL
 import Data.Maybe
 import Data.Text (Text)
 import qualified Data.Text as T
+import Data.Time.Calendar
+import Data.Time.Clock
 import Data.Void
+import Text.Read (readMaybe)
 
 import Database.Beam
 import Database.Beam.Backend.SQL
@@ -26,16 +30,21 @@ import Common.Slack.Types
 
 import Backend.Import (SlackDb (..))
 
+-- Learnings and observations:
+-- * Megaparsec tutorial is long. Summarize key points to know?
+--   * For someone that already is basically familiar with parser combinators
+-- * Testing using hspec-megaparsec
+-- * Importance of `try`
 
 data SearchModifier
   = SearchModifier_From Text  -- ^ Sent by person
   | SearchModifier_In Text  -- ^ In channel
+  | SearchModifier_During Day
   -- | SearchModifier_Before Day
   -- | SearchModifier_After Day
   | SearchModifier_HasPin
   -- | HasLink
   -- | HasEmoji EmojiCode
-  -- | SearchModifier_During (Either Day (Either Int Int)  -- On day, month or year.
   deriving (Show, Generic)
 
 newtype SearchKeyword = SearchKeyword { unSearchKeyword :: Text }
@@ -47,6 +56,20 @@ searchModifier :: Parser SearchModifier
 searchModifier =
       try (SearchModifier_From <$> attribute "from")
   <|> try (SearchModifier_In <$> attribute "in")
+  <|>     (SearchModifier_During <$> do
+              -- TODO: parse this properly!
+              -- FIXME: this is not throwing properly on invalid days
+              let parseNum :: Read a => String -> Parser a
+                  parseNum e = maybe (fail e :: Parser a) pure =<< fmap readMaybe (some digitChar)
+              void $ try $ string "during:"
+              year :: Integer <- parseNum "Expected year"
+              _ <- string "-"
+              month :: Int <- parseNum "Expected month"
+              _ <- string "-"
+              day :: Int <- parseNum "Expected day"
+              -- TODO: get rid of fromJust
+              maybe (fail "Invalid day") pure $ fromGregorianValid year month day
+          )
   <|> try (SearchModifier_HasPin <$ string "has:pin")
 
 searchKeyword :: Parser SearchKeyword
@@ -58,42 +81,37 @@ attribute name = do
   _ <- string ":"
   T.pack <$> some alphaNumChar
 
+-- TODO: Add unit tests for this function.
 parseSearchQuery :: Text -> Either (ParseError Char Void) [Either SearchModifier SearchKeyword]
 parseSearchQuery q = runParser p "<user-query>" q
   where
-    p = sepBy (Left <$> try searchModifier <|> Right <$> searchKeyword) space1
+    p = sepBy (Left <$> searchModifier <|> Right <$> searchKeyword) space1
+
 
 data MessageFilters = MessageFilters
   { _messageFilters_terms :: [SearchKeyword]
   , _messageFilters_from :: [Text]
   , _messageFilters_in :: [Text]
+  , _messageFilters_during :: [Day]
   , _messageFilters_hasPin :: Maybe ()
-  -- , _messageFilters_after :: Maybe Day
-  -- , _c_before :: Maybe Day
-  -- , _c_during :: [Either UTCTime UTCTime]
   }
   deriving (Show, Generic)
 
 makeLenses ''MessageFilters
 
 allMessages :: MessageFilters
-allMessages = MessageFilters [] [] [] Nothing
+allMessages = MessageFilters [] [] [] [] Nothing
 
 mkMessageFilters :: [Either SearchModifier SearchKeyword] -> MessageFilters
-mkMessageFilters = foldl f ini
+mkMessageFilters = foldl f allMessages
   where
-    ini = MessageFilters mempty mempty mempty Nothing
     f mf = \case
       Right kw -> mf & messageFilters_terms %~ (kw:)
       Left md -> case md of
         SearchModifier_From user -> mf & messageFilters_from %~ (user:)
         SearchModifier_In chan -> mf & messageFilters_in %~ (chan:)
+        SearchModifier_During day -> mf & messageFilters_during %~ (day:)
         SearchModifier_HasPin -> mf & messageFilters_hasPin ?~ ()
-
-demo :: IO ()
-demo = parseTest
-  (sepBy (Left <$> try searchModifier <|> Right <$> searchKeyword) space1)
-  "from:srid hello world  has:pin in:general more  query"
 
 messageFilters
   :: forall be s.
@@ -101,7 +119,7 @@ messageFilters
      , BeamSqlBackendIsString be Text
      , HasSqlValueSyntax (BeamSqlBackendValueSyntax be) Text
      , HasSqlEqualityCheck be Text
-     -- , HasSqlValueSyntax (BeamSqlBackendValueSyntax be) UTCTime
+     , HasSqlValueSyntax (BeamSqlBackendValueSyntax be) UTCTime
      )
   => MessageFilters
   -> Q be SlackDb s (MessageT (QExpr be s))
@@ -111,7 +129,13 @@ messageFilters mf = filter_ $ \msg -> foldl (&&.) (val_ True) $ catMaybes $
       msgContaining msg . unSearchKeyword <$> mf ^. messageFilters_terms
   , maybe Nothing (Just . foldl1 (||.)) $ NEL.nonEmpty $
       msgFrom msg <$> mf ^. messageFilters_from
+  , maybe Nothing (Just . foldl1 (||.)) $ NEL.nonEmpty $
+      msgDuring msg <$> mf ^. messageFilters_during
   ]
   where
     msgContaining msg q = _messageText msg `like_` val_ ("%" <> q <> "%")
     msgFrom msg (user :: Text) = _messageUserName msg ==. just_ (val_ user) -- FIXME: join with userName
+    msgDuring msg day = _messageTs msg >=. val_ fromTs &&. _messageTs msg <. val_ toTs
+      where
+        fromTs = UTCTime day 0
+        toTs = UTCTime (addDays 1 day) 0

--- a/backend/src/Backend/Query.hs
+++ b/backend/src/Backend/Query.hs
@@ -95,7 +95,6 @@ demo = parseTest
   (sepBy (Left <$> try searchModifier <|> Right <$> searchKeyword) space1)
   "from:srid hello world  has:pin in:general more  query"
 
-
 messageFilters
   :: forall be s.
      ( BeamSqlBackend be

--- a/backend/src/Backend/Query.hs
+++ b/backend/src/Backend/Query.hs
@@ -56,32 +56,41 @@ searchModifier :: Parser SearchModifier
 searchModifier =
       try (SearchModifier_From <$> attribute "from")
   <|> try (SearchModifier_In <$> attribute "in")
-  <|>     (SearchModifier_During <$> do
-              -- TODO: parse this properly!
-              -- FIXME: this is not throwing properly on invalid days
-              let parseNum :: Read a => String -> Parser a
-                  parseNum e = maybe (fail e :: Parser a) pure =<< fmap readMaybe (some digitChar)
-              void $ try $ string "during:"
-              year :: Integer <- parseNum "Expected year"
-              _ <- string "-"
-              month :: Int <- parseNum "Expected month"
-              _ <- string "-"
-              day :: Int <- parseNum "Expected day"
-              -- TODO: get rid of fromJust
-              maybe (fail "Invalid day") pure $ fromGregorianValid year month day
-          )
+  <|>     (SearchModifier_During <$> dayParser)
   <|> try (SearchModifier_HasPin <$ string "has:pin")
 
+dayParser :: Parser Day
+dayParser = do
+  let parseNum :: Read a => String -> Parser a
+      parseNum e = maybe (fail e :: Parser a) pure =<< fmap readMaybe (some digitChar)
+  void $ try $ string "during:"
+  year :: Integer <- parseNum "Expected year"
+  _ <- string "-"
+  month :: Int <- parseNum "Expected month"
+  _ <- string "-"
+  d :: Int <- parseNum "Expected day"
+  maybe (fail "Invalid day") pure $ fromGregorianValid year month d
+
 searchKeyword :: Parser SearchKeyword
-searchKeyword = SearchKeyword . T.pack <$> some alphaNumChar  -- TODO: support quoted strings
+searchKeyword =
+      (SearchKeyword <$> quotedText)
+  <|> (SearchKeyword <$> someWord)
+
+quotedText :: Parser Text
+quotedText = do
+  void $ try (string "\"")
+  s <- T.pack <$> some (satisfy (/= '"'))
+  void $ string "\""
+  pure s
+
+someWord :: Parser Text
+someWord = T.pack <$> some alphaNumChar -- TODO: Review the accuracy of this
 
 attribute :: Text -> Parser Text
 attribute name = do
-  _ <- string name
-  _ <- string ":"
+  void $ string $ name <> ":"
   T.pack <$> some alphaNumChar
 
--- TODO: Add unit tests for this function.
 parseSearchQuery :: Text -> Either (ParseError Char Void) [Either SearchModifier SearchKeyword]
 parseSearchQuery q = runParser p "<user-query>" q
   where

--- a/backend/src/Backend/Query.hs
+++ b/backend/src/Backend/Query.hs
@@ -101,7 +101,6 @@ messageFilters
      ( BeamSqlBackend be
      , BeamSqlBackendIsString be Text
      , HasSqlValueSyntax (BeamSqlBackendValueSyntax be) Text
-     , HasSqlValueSyntax (BeamSqlBackendValueSyntax be) (Maybe Text)
      , HasSqlEqualityCheck be Text
      -- , HasSqlValueSyntax (BeamSqlBackendValueSyntax be) UTCTime
      )
@@ -116,4 +115,4 @@ messageFilters mf = filter_ $ \msg -> foldl (&&.) (val_ True) $ catMaybes $
   ]
   where
     msgContaining msg q = _messageText msg `like_` val_ ("%" <> q <> "%")
-    msgFrom msg user = _messageUser msg ==. val_ (Just user)
+    msgFrom msg (user :: Text) = _messageUserName msg ==. just_ (val_ user) -- FIXME: join with userName

--- a/backend/src/Backend/Query.hs
+++ b/backend/src/Backend/Query.hs
@@ -1,79 +1,74 @@
-{-# LANGUAGE GADTs #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 module Backend.Query where
 
+import Data.Foldable (foldr1)
+import Data.List.NonEmpty (NonEmpty (..))
+import qualified Data.List.NonEmpty as NEL
 import Data.Text (Text)
 import qualified Data.Text as T
 import Data.Time.Calendar
-import Data.Foldable (foldr1)
 import Data.Time.Clock
-import qualified Data.List.NonEmpty as NEL
 import Data.Void
-import Data.List.NonEmpty (NonEmpty (..))
 
 import Database.Beam
 import Database.Beam.Backend.SQL
 import Text.Megaparsec
 import Text.Megaparsec.Char
-import qualified Text.Megaparsec.Char.Lexer as L
+-- import qualified Text.Megaparsec.Char.Lexer as L
 
 import Common.Slack.Types
 
 import Backend.Import (SlackDb (..))
 
-data SearchQuery
-  = SearchQuery_Like Text
-  | SearchQuery_Or (NonEmpty SearchQuery)
-  | SearchQuery_From Text
-  | SearchQuery_To Text
-  deriving (Show)
+data SearchModifier
+  = SearchModifier_From Text  -- ^ Sent by person
+  | SearchModifier_In Text  -- ^ In channel
+  | SearchModifier_Before Day
+  | SearchModifier_After Day
+  -- | SearchModifier_During (Either Day (Either Int Int)  -- On day, month or year.
+  deriving Show
+
+newtype SearchKeyword = SearchKeyword Text
+  deriving Show
 
 type Parser = Parsec Void Text
 
-someTerm :: Parser Text
-someTerm = fmap T.pack $ some alphaNumChar
+searchModifier :: Parser SearchModifier
+searchModifier =
+      try (SearchModifier_From <$> attribute "from")
+  <|> try (SearchModifier_In <$> attribute "in")
 
-searchQuery :: Parser SearchQuery
-searchQuery = fmap combineOr p
-  where
-    p =
-        (SearchQuery_From <$> (L.symbol space "from:" >> someTerm))
-      <|> (SearchQuery_To <$> (L.symbol space "to:" >> someTerm))
-      <|> (SearchQuery_Like . T.pack <$> some alphaNumChar) -- (sepEndBy1 printChar space1))
-    combineOr = id
-  -- <|> (SearchQuery_Or . fromJust . NEL.nonEmpty <$> sepEndBy1 searchQuery space1)
+searchKeyword :: Parser SearchKeyword
+searchKeyword = SearchKeyword . T.pack <$> some alphaNumChar  -- TODO: support quoted strings
+
+attribute :: Text -> Parser Text
+attribute name = do
+  _ <- string name
+  _ <- string ":"
+  T.pack <$> some alphaNumChar
 
 demo :: IO ()
-demo = parseTest searchQuery "Hello world"
+demo = parseTest (sepBy (Left <$> try searchModifier <|> Right <$> searchKeyword) space1) "from:srid hello world  in:general more  query"
 
-data C = C
+data MessageFilters = MessageFilters
   { _c_terms :: [Text]
-  , _c_after :: Maybe UTCTime
-  , _c_before :: Maybe UTCTime
-  , _c_during :: Maybe (Either UTCTime UTCTime)
-  , _c_from :: Maybe [Text]
-  , _c_to :: Maybe [Text]
+  , _c_from :: [Text]
+  , _c_after :: Maybe Day
+  , _c_before :: Maybe Day
+  -- , _c_during :: [Either UTCTime UTCTime]
   }
 
--- TODO: Provide example queries for each constructor and display that in home
--- page. (Store queries in config file)
 data Query
   = Query_Day Day
   | Query_Like Text
   | Query_And (NonEmpty Text)
-  -- | Query_Exact Text
-  -- | Query_Or Query Query
-  -- | Query_And Query Query
-  -- | Query_After UTCTime
-  -- | Query_Between UTCTime
-  -- | Query_During (Either Month Year)
-  -- | Query_From SlackUser
 
 parseQuery :: Text -> Query
 parseQuery query = case NEL.nonEmpty (T.words query) of

--- a/backend/src/Backend/Search.hs
+++ b/backend/src/Backend/Search.hs
@@ -7,95 +7,22 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell #-}
-module Backend.Query where
+module Backend.Search where
 
 import Control.Lens hiding ((<.))
-import Control.Monad
 import qualified Data.List.NonEmpty as NEL
 import Data.Maybe
 import Data.Text (Text)
-import qualified Data.Text as T
 import Data.Time.Calendar
 import Data.Time.Clock
-import Data.Void
-import Text.Read (readMaybe)
 
 import Database.Beam
 import Database.Beam.Backend.SQL
-import Text.Megaparsec
-import Text.Megaparsec.Char
--- import qualified Text.Megaparsec.Char.Lexer as L
 
 import Common.Slack.Types
 
 import Backend.Import (SlackDb (..))
-
--- Learnings and observations:
--- * Megaparsec tutorial is long. Summarize key points to know?
---   * For someone that already is basically familiar with parser combinators
--- * Testing using hspec-megaparsec
--- * Importance of `try`
-
-data SearchModifier
-  = SearchModifier_From Text  -- ^ Sent by person
-  | SearchModifier_In Text  -- ^ In channel
-  | SearchModifier_During Day
-  -- | SearchModifier_Before Day
-  -- | SearchModifier_After Day
-  | SearchModifier_HasPin
-  -- | HasLink
-  -- | HasEmoji EmojiCode
-  deriving (Show, Generic)
-
-newtype SearchKeyword = SearchKeyword { unSearchKeyword :: Text }
-  deriving (Show, Generic)
-
-type Parser = Parsec Void Text
-
-searchModifier :: Parser SearchModifier
-searchModifier =
-      try (SearchModifier_From <$> attribute "from")
-  <|> try (SearchModifier_In <$> attribute "in")
-  <|>     (SearchModifier_During <$> dayParser)
-  <|> try (SearchModifier_HasPin <$ string "has:pin")
-
-dayParser :: Parser Day
-dayParser = do
-  let parseNum :: Read a => String -> Parser a
-      parseNum e = maybe (fail e :: Parser a) pure =<< fmap readMaybe (some digitChar)
-  void $ try $ string "during:"
-  year :: Integer <- parseNum "Expected year"
-  _ <- string "-"
-  month :: Int <- parseNum "Expected month"
-  _ <- string "-"
-  d :: Int <- parseNum "Expected day"
-  maybe (fail "Invalid day") pure $ fromGregorianValid year month d
-
-searchKeyword :: Parser SearchKeyword
-searchKeyword =
-      (SearchKeyword <$> quotedText)
-  <|> (SearchKeyword <$> someWord)
-
-quotedText :: Parser Text
-quotedText = do
-  void $ try (string "\"")
-  s <- T.pack <$> some (satisfy (/= '"'))
-  void $ string "\""
-  pure s
-
-someWord :: Parser Text
-someWord = T.pack <$> some alphaNumChar -- TODO: Review the accuracy of this
-
-attribute :: Text -> Parser Text
-attribute name = do
-  void $ string $ name <> ":"
-  T.pack <$> some alphaNumChar
-
-parseSearchQuery :: Text -> Either (ParseError Char Void) [Either SearchModifier SearchKeyword]
-parseSearchQuery q = runParser p "<user-query>" q
-  where
-    p = sepBy (Left <$> searchModifier <|> Right <$> searchKeyword) space1
-
+import Backend.Search.Parser (SearchKeyword(..), SearchModifier(..))
 
 data MessageFilters = MessageFilters
   { _messageFilters_terms :: [SearchKeyword]

--- a/backend/src/Backend/Search/Parser.hs
+++ b/backend/src/Backend/Search/Parser.hs
@@ -1,0 +1,81 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Backend.Search.Parser where
+
+import Control.Monad
+import Data.Text (Text)
+import qualified Data.Text as T
+import Data.Time.Calendar
+import Data.Void
+import Text.Read (readMaybe)
+import GHC.Generics
+
+import Text.Megaparsec
+import Text.Megaparsec.Char
+
+data SearchModifier
+  = SearchModifier_From Text  -- ^ Sent by person
+  | SearchModifier_In Text  -- ^ In channel
+  | SearchModifier_During Day
+  -- | SearchModifier_Before Day
+  -- | SearchModifier_After Day
+  | SearchModifier_HasPin
+  -- | HasLink
+  -- | HasEmoji EmojiCode
+  deriving (Show, Generic)
+
+newtype SearchKeyword = SearchKeyword { unSearchKeyword :: Text }
+  deriving (Show, Generic)
+
+type Parser = Parsec Void Text
+
+searchModifier :: Parser SearchModifier
+searchModifier =
+      try (SearchModifier_From <$> attribute "from")
+  <|> try (SearchModifier_In <$> attribute "in")
+  <|>     (SearchModifier_During <$> dayParser)
+  <|> try (SearchModifier_HasPin <$ string "has:pin")
+
+dayParser :: Parser Day
+dayParser = do
+  let parseNum :: Read a => String -> Parser a
+      parseNum e = maybe (fail e :: Parser a) pure =<< fmap readMaybe (some digitChar)
+  void $ try $ string "during:"
+  year :: Integer <- parseNum "Expected year"
+  _ <- string "-"
+  month :: Int <- parseNum "Expected month"
+  _ <- string "-"
+  d :: Int <- parseNum "Expected day"
+  maybe (fail "Invalid day") pure $ fromGregorianValid year month d
+
+searchKeyword :: Parser SearchKeyword
+searchKeyword =
+      (SearchKeyword <$> quotedText)
+  <|> (SearchKeyword <$> someWord)
+
+quotedText :: Parser Text
+quotedText = do
+  void $ try (string "\"")
+  s <- T.pack <$> some (satisfy (/= '"'))
+  void $ string "\""
+  pure s
+
+someWord :: Parser Text
+someWord = T.pack <$> some alphaNumChar -- TODO: Review the accuracy of this
+
+attribute :: Text -> Parser Text
+attribute name = do
+  void $ string $ name <> ":"
+  T.pack <$> some alphaNumChar
+
+parseSearchQuery :: Text -> Either (ParseError Char Void) [Either SearchModifier SearchKeyword]
+parseSearchQuery q = runParser p "<user-query>" q
+  where
+    p = sepBy (Left <$> searchModifier <|> Right <$> searchKeyword) space1

--- a/common/src/Common/Slack/Types.hs
+++ b/common/src/Common/Slack/Types.hs
@@ -124,19 +124,20 @@ instance FromJSON Message where
     type_ <- o .: "type"
     subtype <- o .:? "subtype"
     user <- o .:? "user"
-    userid <- o .:? "user_id"
+    username <- o .:? "user_name"
     botid <- o .:? "bot_id"
     txt <- o .: "text"
     msgid <- o .:? "client_msg_id"
     ts <- parseSlackTimestamp =<< o .: "ts"
     channelName <- o .:? "channel_name"
-    pure $ Message type_ subtype user userid botid txt msgid ts channelName
+    pure $ Message type_ subtype user username botid txt msgid ts channelName
 
 instance ToJSON Message where
   toJSON m = object
     [ "type" .= _messageType m
     , "subtype" .= _messageSubtype m
     , "user" .= _messageUser m
+    , "user_name" .= _messageUserName m
     , "bot_id" .= _messageBotId m
     , "text" .= _messageText m
     , "client_msg_id" .= _messageClientMsgId m

--- a/common/src/Common/Slack/Types.hs
+++ b/common/src/Common/Slack/Types.hs
@@ -85,6 +85,7 @@ data MessageT f = Message
   { _messageType :: Columnar f Text
   , _messageSubtype :: Columnar f (Maybe Text)
   , _messageUser :: Columnar f (Maybe Text) -- Join with User ID
+  , _messageUserName :: Columnar f (Maybe Text) -- Because I'm lazy to do a join. :-P
   , _messageBotId :: Columnar f (Maybe Text)
   , _messageText :: Columnar f Text
   , _messageClientMsgId :: Columnar f (Maybe Text) -- XXX: This can be empty?
@@ -123,12 +124,13 @@ instance FromJSON Message where
     type_ <- o .: "type"
     subtype <- o .:? "subtype"
     user <- o .:? "user"
+    userid <- o .:? "user_id"
     botid <- o .:? "bot_id"
     txt <- o .: "text"
     msgid <- o .:? "client_msg_id"
     ts <- parseSlackTimestamp =<< o .: "ts"
     channelName <- o .:? "channel_name"
-    pure $ Message type_ subtype user botid txt msgid ts channelName
+    pure $ Message type_ subtype user userid botid txt msgid ts channelName
 
 instance ToJSON Message where
   toJSON m = object

--- a/common/src/Common/Types.hs
+++ b/common/src/Common/Types.hs
@@ -5,4 +5,4 @@ import Data.Pagination
 import Common.Slack.Types
 import Common.Slack.Types.Auth
 
-type MessagesResponse = Either NotAuthorized (SlackUser, ([User], Paginated Message))
+type MessagesResponse = Either NotAuthorized (SlackUser, Paginated Message)

--- a/frontend/src/Frontend.hs
+++ b/frontend/src/Frontend.hs
@@ -122,10 +122,10 @@ frontend = Frontend
         slackLoginButton r = elAttr "a" ("href" =: r) $
           elAttr "img" ("src" =: "https://api.slack.com/img/sign_in_with_slack.png") blank
 
-    renderMessagesWithPagination r mkR (us, pm) = do
+    renderMessagesWithPagination r mkR pm = do
       let pgnW = dyn_ $ ffor r $ \pr ->
             paginationNav pm $ \p' -> mkR :/ (PaginatedRoute (p', paginatedRouteValue pr))
-      pgnW >> messageList (us, pm) >> pgnW
+      pgnW >> messageList pm >> pgnW
 
     showDay day = T.pack $ printf "%d-%02d-%02d" y m d
       where


### PR DESCRIPTION
For #14 

- [x] Use basic megaparsec 
- [x] Build final Query structure out of parsed values
- [x] Extend `filterQuery` to use the new structure, and test
- [ ] Write unit tests for parsers (using [this](https://hackage.haskell.org/package/hspec-megaparsec-2.0.0/docs/Test-Hspec-Megaparsec.html))
- [x] Support for `during:<day>` to replace Day query
- [x] Support for exact match using quotes (`"foo bar"`)