### PR TITLE
Extend PaginatedRoute to include a row cursor

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,8 @@
 - Fix extra space around search query breaking app
 - Read directly from the Zip archive
 - Add `after:` and `before:` to search query
+- Message permalinks no longer have page numbers in their URL, and are thus
+  "permanent".
 
 ## v0.2 - 2019/05/11
 

--- a/backend/src/Backend.hs
+++ b/backend/src/Backend.hs
@@ -11,7 +11,6 @@ import Control.Arrow ((&&&))
 import Control.Exception.Safe (throwString)
 import Control.Lens
 import Data.Aeson
-import Data.Default (def)
 import Data.Dependent.Sum (DSum ((:=>)))
 import Data.Foldable (foldl')
 import Data.Functor.Identity (Identity (..))
@@ -35,7 +34,6 @@ import Obelisk.Route hiding (decode, encode)
 
 import Common.Route
 import Common.Slack.Types
-import Common.Slack.Types.Auth
 import Common.Slack.Types.Search
 import Common.Types
 
@@ -78,14 +76,6 @@ backend = Backend
                     ]
               pure $ Right (u, examples)
           writeLBS $ encode resp
-        BackendRoute_LocateMessage :=> Identity (ch, t) -> do
-          authorizeUser cfg (renderBackendRoute (_backendConfig_enc cfg) $ BackendRoute_LocateMessage :/ (ch, t)) >>= \case
-            Left e -> redirect $ T.encodeUtf8 $ notAuthorizedLoginLink e
-            Right _ -> do
-              let mf = def & messageFilters_in .~ [ch]
-              page <- locateMessage cfg mf t
-              redirect $ T.encodeUtf8 $ (renderFrontendRoute (_backendConfig_enc cfg) $
-                FrontendRoute_Search :/ PaginatedRoute (Left page, "in:" <> ch)) -- <> "#" <> (formatSlackTimestamp t)
         BackendRoute_SearchMessages :=> Identity pQuery -> do
           resp :: MessagesResponse <- authorizeUser cfg (renderFrontendRoute (_backendConfig_enc cfg) $ FrontendRoute_Search :/ pQuery) >>= \case
             Left e -> pure $ Left e

--- a/backend/src/Backend.hs
+++ b/backend/src/Backend.hs
@@ -83,18 +83,13 @@ backend = Backend
             Left e -> redirect $ T.encodeUtf8 $ notAuthorizedLoginLink e
             Right _ -> do
               let mf = def & messageFilters_in .~ [ch]
-              page <- liftIO $ runBeamSqlite (_backendConfig_sqliteConn cfg) $ do
-                total <- countMessages cfg mf
-                after <- countMessages cfg $ mf & messageFilters_at ?~ t
-                let pgSize = fromIntegral $ _backendConfig_pageSize cfg
-                pure $ fromIntegral $ 1 + (toInteger (total - after) `quot` pgSize)
+              page <- locateMessage cfg mf t
               redirect $ T.encodeUtf8 $ (renderFrontendRoute (_backendConfig_enc cfg) $
-                FrontendRoute_Search :/ PaginatedRoute (page, "in:" <> ch)) -- <> "#" <> (formatSlackTimestamp t)
+                FrontendRoute_Search :/ PaginatedRoute (Left page, "in:" <> ch)) -- <> "#" <> (formatSlackTimestamp t)
         BackendRoute_SearchMessages :=> Identity pQuery -> do
           resp :: MessagesResponse <- authorizeUser cfg (renderFrontendRoute (_backendConfig_enc cfg) $ FrontendRoute_Search :/ pQuery) >>= \case
             Left e -> pure $ Left e
             Right u -> do
-              pagination <- liftIO $ mkPaginationFromRoute cfg pQuery
               case parseSearchQuery (paginatedRouteValue pQuery) of
                 Left err -> do
                   liftIO $ putStrLn $ show err
@@ -102,12 +97,22 @@ backend = Backend
                 Right q -> do
                   let mf = mkMessageFilters q
                   liftIO $ putStrLn $ show mf
+                  pagination <- liftIO $ mkPaginationFromRoute cfg mf pQuery
                   msgs <- queryMessages cfg mf $ pagination
                   pure $ Right $ (u, Right (mf, msgs))
           writeLBS $ encode resp
   }
   where
-    mkPaginationFromRoute cfg p = mkPagination (_backendConfig_pageSize cfg) (paginatedRoutePageIndex p)
+    mkPaginationFromRoute cfg mf p = mkPagination (_backendConfig_pageSize cfg) =<< case paginatedRouteCursor p of
+      Left pg -> pure pg
+      Right t -> locateMessage cfg mf t
+
+    locateMessage cfg mf t = do
+      liftIO $ runBeamSqlite (_backendConfig_sqliteConn cfg) $ do
+        total <- countMessages cfg mf
+        after <- countMessages cfg $ mf & messageFilters_at ?~ t
+        let pgSize = fromIntegral $ _backendConfig_pageSize cfg
+        pure $ fromIntegral $ 1 + (toInteger (total - after) `quot` pgSize)
 
     countMessages cfg mf = do
       liftIO $ runBeamSqlite (_backendConfig_sqliteConn cfg) $ do

--- a/common/src/Common/Route.hs
+++ b/common/src/Common/Route.hs
@@ -20,6 +20,7 @@ import Data.Maybe
 import Data.Text (Text)
 import qualified Data.Text as T
 import Data.Time.Clock
+import qualified Data.Map as Map
 import GHC.Natural
 
 import Obelisk.OAuth.Authorization
@@ -29,16 +30,18 @@ import Obelisk.Route.TH
 import Common.Slack.Internal
 
 
-newtype PaginatedRoute a = PaginatedRoute { unPaginatedRoute ::  (Natural, a) }
+newtype PaginatedRoute cursor a = PaginatedRoute
+  { unPaginatedRoute ::  (Either Natural cursor, a)
+  }
   deriving (Eq, Show, Ord)
 
-mkPaginatedRouteAtPage1 :: a -> PaginatedRoute a
-mkPaginatedRouteAtPage1 = PaginatedRoute . (1, )
+mkPaginatedRouteAtPage1 :: a -> PaginatedRoute cursor a
+mkPaginatedRouteAtPage1 = PaginatedRoute . (Left 1, )
 
-paginatedRoutePageIndex :: PaginatedRoute a -> Natural
-paginatedRoutePageIndex = fst . unPaginatedRoute
+paginatedRouteCursor :: PaginatedRoute cursor a -> Either Natural cursor
+paginatedRouteCursor = fst . unPaginatedRoute
 
-paginatedRouteValue :: PaginatedRoute a -> a
+paginatedRouteValue :: PaginatedRoute cursor a -> a
 paginatedRouteValue = snd . unPaginatedRoute
 
 data BackendRoute :: * -> * where
@@ -47,11 +50,11 @@ data BackendRoute :: * -> * where
   BackendRoute_OAuth :: BackendRoute (R OAuth)
   BackendRoute_GetSearchExamples :: BackendRoute ()
   BackendRoute_LocateMessage :: BackendRoute (Text, UTCTime) -- Channel and timestamp
-  BackendRoute_SearchMessages :: BackendRoute (PaginatedRoute Text)
+  BackendRoute_SearchMessages :: BackendRoute (PaginatedRoute UTCTime Text)
 
 data FrontendRoute :: * -> * where
   FrontendRoute_Home :: FrontendRoute ()
-  FrontendRoute_Search :: FrontendRoute (PaginatedRoute Text)
+  FrontendRoute_Search :: FrontendRoute (PaginatedRoute UTCTime Text)
 
 backendRouteEncoder
   :: Encoder (Either Text) Identity (R (Sum BackendRoute (ObeliskRoute FrontendRoute))) PageName
@@ -63,13 +66,13 @@ backendRouteEncoder = handleEncoder (const (InL BackendRoute_Missing :/ ())) $
       BackendRoute_GetSearchExamples -> PathSegment "get-search-examples" $ unitEncoder mempty
       BackendRoute_LocateMessage -> PathSegment "locate-message" locateMessageEncoder
       BackendRoute_SearchMessages -> PathSegment "search-messages" $
-        paginatedEncoder textEncoderImpl
+        paginatedEncoder utcTimeEncoderImpl textEncoderImpl
     InR obeliskRoute -> obeliskRouteSegment obeliskRoute $ \case
       -- The encoder given to PathEnd determines how to parse query parameters,
       -- in this example, we have none, so we insist on it.
       FrontendRoute_Home -> PathEnd $ unitEncoder mempty
       FrontendRoute_Search -> PathSegment "search" $
-        paginatedEncoder textEncoderImpl
+        paginatedEncoder utcTimeEncoderImpl textEncoderImpl
 
 -- TODO: compose instead of writing by hand
 locateMessageEncoder
@@ -83,22 +86,41 @@ locateMessageEncoder = unsafeMkEncoder $ EncoderImpl
 
 paginatedEncoder
   :: (Applicative check, MonadError Text parse)
-  => EncoderImpl parse a [Text]
-  -> Encoder check parse (PaginatedRoute a) PageName
-paginatedEncoder aEncoderImpl = unsafeMkEncoder $ EncoderImpl
-    { _encoderImpl_decode = \(p:ps, _query) -> do
+  => EncoderImpl parse (Maybe cursor) [Text]
+  -> EncoderImpl parse a [Text]
+  -> Encoder check parse (PaginatedRoute cursor a) PageName
+paginatedEncoder cursorEncoderImpl aEncoderImpl = unsafeMkEncoder $ EncoderImpl
+    { _encoderImpl_decode = \(p:ps, query) -> do
+        mcursor <- _encoderImpl_decode cursorEncoderImpl ps
         a <- _encoderImpl_decode aEncoderImpl [p]
-        pure $ PaginatedRoute
-          ( fromMaybe 1 $ read . T.unpack <$> listToMaybe ps
-          , a
-          )
-    , _encoderImpl_encode = \(PaginatedRoute (n, a)) ->
-        ( _encoderImpl_encode aEncoderImpl a <> (if n > 1 then [T.pack (show n)] else mempty)
-        , mempty
+        case mcursor of
+          Nothing -> pure $ PaginatedRoute
+            ( Left $ fromMaybe 1 $ fmap (read . T.unpack) =<< Map.lookup "p" query
+            , a
+            )
+          Just cursor -> pure $ PaginatedRoute
+            ( Right cursor
+            , a
+            )
+    , _encoderImpl_encode = \(PaginatedRoute (nc, a)) ->
+        ( _encoderImpl_encode aEncoderImpl a <> (either mempty (_encoderImpl_encode cursorEncoderImpl . Just) nc)
+        , either (Map.singleton "p" . Just . T.pack . show) mempty nc
         )
     }
 
--- TODO: shouldn't need this.
+-- TODO: shouldn't need the Impl implementations with
+-- https://github.com/obsidiansystems/obelisk/pull/426/files
+utcTimeEncoderImpl
+  :: (MonadError Text parse)
+  => EncoderImpl parse (Maybe UTCTime) [Text]
+utcTimeEncoderImpl = EncoderImpl
+  { _encoderImpl_decode = \ps -> case ps of
+      [] -> pure Nothing
+      [t] -> Just <$> parseSlackTimestamp t
+      _ -> throwError "More than 1 path element for utcTimeEncoderImpl"
+  , _encoderImpl_encode = \mt -> (maybe [] (pure . formatSlackTimestamp) mt)
+  }
+
 textEncoderImpl
   :: (MonadError Text parse)
   => EncoderImpl parse Text [Text]

--- a/frontend/src/Frontend.hs
+++ b/frontend/src/Frontend.hs
@@ -61,7 +61,7 @@ frontend = Frontend
                     FrontendRoute_Home :=> Identity () -> ""
                     FrontendRoute_Search :=> Identity pr -> paginatedRouteValue pr
               searchInputWidgetWithRoute query $ \q ->
-                FrontendRoute_Search :/ (PaginatedRoute (1, T.strip q))
+                FrontendRoute_Search :/ (PaginatedRoute (Left 1, T.strip q))
 
           fmap switchDyn $ subRoute $ \case
             FrontendRoute_Home -> do
@@ -130,5 +130,5 @@ frontend = Frontend
 
     renderMessagesWithPagination r mkR pm = do
       let pageW = dyn_ $ ffor r $ \pr ->
-            paginationNav pm $ \p' -> mkR :/ (PaginatedRoute (p', paginatedRouteValue pr))
+            paginationNav pm $ \p' -> mkR :/ (PaginatedRoute (Left p', paginatedRouteValue pr))
       pageW >> messageList pm >> pageW

--- a/frontend/src/Frontend.hs
+++ b/frontend/src/Frontend.hs
@@ -61,12 +61,12 @@ frontend = Frontend
                     FrontendRoute_Home :=> Identity () -> ""
                     FrontendRoute_Search :=> Identity pr -> paginatedRouteValue pr
               searchInputWidgetWithRoute query $ \q ->
-                FrontendRoute_Search :/ (PaginatedRoute (Left 1, T.strip q))
+                FrontendRoute_Search :/ (mkPaginatedRouteAtPage1 $ T.strip q)
 
           fmap switchDyn $ subRoute $ \case
             FrontendRoute_Home -> do
               resp <- getSearchExamples
-              widgetHold_ blank $ ffor resp $ \case
+              widgetHold_ loader $ ffor resp $ \case
                 Nothing -> text "Unable to load search examples"
                 Just (Left na) -> notAuthorizedWidget na
                 Just (Right (_, examples)) -> do
@@ -83,7 +83,7 @@ frontend = Frontend
             FrontendRoute_Search -> do
               r  <- askRoute
               resp <- getMessages r (BackendRoute_SearchMessages :/)
-              widgetHold_ (divClass "ui loading segment" blank) $ ffor resp $ \case
+              widgetHold_ loader $ ffor resp $ \case
                 Nothing -> text "Something went wrong"
                 Just (Left na) -> notAuthorizedWidget na
                 Just (Right (_, Left ())) -> do
@@ -116,6 +116,9 @@ frontend = Frontend
             divClass "item" $ text $ "Welcome " <> name
   }
   where
+    loader :: DomBuilder t m => m ()
+    loader = divClass "ui loading segment" blank
+
     notAuthorizedWidget :: DomBuilder t m => NotAuthorized -> m ()
     notAuthorizedWidget = \case
       NotAuthorized_RequireLogin grantHref -> divClass "ui segment" $ do

--- a/frontend/src/Frontend/Message.hs
+++ b/frontend/src/Frontend/Message.hs
@@ -48,7 +48,7 @@ singleMessage msg = do
           case _messageChannelName msg of
             Nothing -> text $ T.pack $ show $ _messageTs msg
             Just ch -> do
-              let rr = renderBackendRoute enc $ BackendRoute_LocateMessage :/ (ch, _messageTs msg)
+              let rr = renderFrontendRoute enc $ FrontendRoute_Search :/ (PaginatedRoute (Right (_messageTs msg), "in:" <> ch))
               elAttr "a" ("href" =: rr) $ text $ T.pack $ show $ _messageTs msg
       elAttr "div" ("class" =: "text") $ do
         renderSlackMessage $ _messageText msg


### PR DESCRIPTION
Fixes #22 

PaginatedRoute effectively can choose between two types of cursors:

1. Page cursor (aka. page index)
1. Row cursor (specific row)

In either case the backend is expected to return a `Paginated a` from which
pagination UI will be derived. Other pages from this UI _will_ contain the page
cursor.

Row cursor will by design only be used by message permalinks.